### PR TITLE
[GLM-13289] Handle the errors that were indicated but weren't exposed

### DIFF
--- a/lib/active_resource/json_errors.rb
+++ b/lib/active_resource/json_errors.rb
@@ -22,8 +22,12 @@ module ActiveResource
       clear unless save_cache
 
       messages.each do |key, errors|
-        errors.each do |error|
-          add(key, error)
+        if errors.blank?
+          add(key.presence || :base, "Shopify indicated an error, but didn't provide any details")
+        else
+          errors.each do |error|
+            add(key, error)
+          end
         end
       end
     end


### PR DESCRIPTION
Closes https://linear.app/gleamio/issue/GLM-13289 and https://app.bugsnag.com/crowd9/gleam/errors/6892c558a9cb01960dbe8263.